### PR TITLE
feat: 표준 API 응답을 위한 GlobalResponseAdvice 구현

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/main/kotlin/com/zunza/gongsamo/common/ApiResponse.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/common/ApiResponse.kt
@@ -1,0 +1,10 @@
+package com.zunza.gongsamo.common
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+data class ApiResponse<T>(
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val data: T,
+    val code: Int,
+    val success: Boolean = code >= 200 && code < 300
+)

--- a/src/main/kotlin/com/zunza/gongsamo/common/CustomException.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/common/CustomException.kt
@@ -1,0 +1,7 @@
+package com.zunza.gongsamo.common
+
+abstract class CustomException(
+    message: String
+) : RuntimeException(message) {
+    abstract fun getStatusCode(): Int
+}

--- a/src/main/kotlin/com/zunza/gongsamo/common/ErrorResponse.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/common/ErrorResponse.kt
@@ -1,0 +1,11 @@
+package com.zunza.gongsamo.common
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+data class ErrorResponse(
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val message: String? = null,
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val messages: List<String?>? = null
+)

--- a/src/main/kotlin/com/zunza/gongsamo/common/GlobalResponseAdvice.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/common/GlobalResponseAdvice.kt
@@ -1,0 +1,78 @@
+package com.zunza.gongsamo.common
+
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.core.MethodParameter
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.server.ServerHttpRequest
+import org.springframework.http.server.ServerHttpResponse
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice
+
+@RestControllerAdvice
+class GlobalResponseAdvice(
+    private val httpServletResponse: HttpServletResponse
+) : ResponseBodyAdvice<Any> {
+
+    override fun supports(
+        returnType: MethodParameter,
+        converterType: Class<out HttpMessageConverter<*>?>
+    ): Boolean {
+        return returnType
+            .containingClass
+            .isAnnotationPresent(RestController::class.java)
+    }
+
+    override fun beforeBodyWrite(
+        body: Any?,
+        returnType: MethodParameter,
+        selectedContentType: MediaType,
+        selectedConverterType: Class<out HttpMessageConverter<*>?>,
+        request: ServerHttpRequest,
+        response: ServerHttpResponse
+    ): Any? {
+        val status: Int = httpServletResponse.status
+        return when (body) {
+            is ApiResponse<*> -> body
+            else -> ApiResponse(body, status)
+        }
+    }
+
+    @ExceptionHandler(CustomException::class)
+    fun customExceptionHandler(
+        e: CustomException
+    ): ResponseEntity<ApiResponse<ErrorResponse>> {
+        val errorResponse = ErrorResponse(e.message)
+        val apiResponse = ApiResponse(errorResponse, e.getStatusCode())
+        return ResponseEntity.status(e.getStatusCode()).body(apiResponse)
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun methodArgumentNotValidExceptionHandler(
+        e: MethodArgumentNotValidException
+    ): ResponseEntity<ApiResponse<ErrorResponse>> {
+        val errorMessages = e.fieldErrors.map { it.defaultMessage }
+
+        val message =  if (errorMessages.count() == 1) errorMessages[0] else null
+        val messages = if (errorMessages.count() > 1) errorMessages else null
+
+        val errorResponse = ErrorResponse(message, messages)
+        val apiResponse = ApiResponse(errorResponse, e.statusCode.value())
+        return ResponseEntity.status(e.statusCode).body(apiResponse)
+    }
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun illegalArgumentExceptionExceptionHandler(
+        e: IllegalArgumentException
+    ): ResponseEntity<ApiResponse<ErrorResponse>> {
+        val status = HttpStatus.BAD_REQUEST
+        val errorResponse = ErrorResponse(e.message)
+        val apiResponse = ApiResponse(errorResponse, status.value())
+        return ResponseEntity.status(status).body(apiResponse)
+    }
+}


### PR DESCRIPTION
- ResponseBodyAdvice 구현: 모든 @RestController의 응답과 예외를 ApiResponse 형식으로 통일했습니다.
- @ExceptionHandler 추가
  - CustomException:  커스텀 예외에 대한 처리를 추가했습니다.
  - MethodArgumentNotValidException: 유효성 검사 실패 시 발생하는 예외를 처리합니다.
  - IllegalArgumentException: 잘못된 인자 값으로 인한 예외를 처리합니다.