### PR TITLE
feat: JWT 기반 인증 및 인가 구현

### DIFF
--- a/src/main/kotlin/com/zunza/gongsamo/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/config/SecurityConfig.kt
@@ -1,0 +1,64 @@
+package com.zunza.gongsamo.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.zunza.gongsamo.security.jwt.JwtAuthenticationFilter
+import com.zunza.gongsamo.security.jwt.JwtExceptionFilter
+import com.zunza.gongsamo.security.jwt.JwtTokenProvider
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig(
+    private val authenticationConfiguration: AuthenticationConfiguration,
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val objectMapper: ObjectMapper
+) {
+    @Bean
+    fun passwordEncoder(): PasswordEncoder =
+        BCryptPasswordEncoder()
+
+    @Bean
+    fun authenticationManager(): AuthenticationManager =
+        authenticationConfiguration.authenticationManager
+
+    @Bean
+    fun securityFilterChain(
+        http: HttpSecurity
+    ): SecurityFilterChain {
+        http
+            .csrf { it.disable() }
+            .httpBasic { it.disable() }
+            .formLogin { it.disable() }
+            .logout { it.disable() }
+            .sessionManagement {
+                it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            }
+
+            .authorizeHttpRequests { authorize ->
+                authorize
+                    .anyRequest().permitAll()
+            }
+
+            .addFilterBefore(
+                JwtExceptionFilter(objectMapper),
+                UsernamePasswordAuthenticationFilter::class.java
+            )
+
+            .addFilterBefore(
+                JwtAuthenticationFilter(jwtTokenProvider),
+                UsernamePasswordAuthenticationFilter::class.java
+            )
+
+        return http.build()
+    }
+}

--- a/src/main/kotlin/com/zunza/gongsamo/security/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/security/jwt/JwtAuthenticationFilter.kt
@@ -1,0 +1,32 @@
+package com.zunza.gongsamo.security.jwt
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.filter.OncePerRequestFilter
+
+class JwtAuthenticationFilter(
+    private val jwtTokenProvider: JwtTokenProvider
+) : OncePerRequestFilter() {
+
+    companion object {
+        private const val AUTHORIZATION_HEADER = "Authorization"
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val jwt: String? = request.getHeader(AUTHORIZATION_HEADER)
+            .extractJwtFromBearerHeader()
+
+        if (!jwt.isNullOrBlank() && jwtTokenProvider.validateJwt(jwt)) {
+            val authentication = jwtTokenProvider.getAuthentication(jwt)
+            SecurityContextHolder.getContext().authentication = authentication
+        }
+
+        filterChain.doFilter(request, response)
+    }
+}

--- a/src/main/kotlin/com/zunza/gongsamo/security/jwt/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/security/jwt/JwtTokenProvider.kt
@@ -1,0 +1,93 @@
+package com.zunza.gongsamo.security.jwt
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.JwtException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import io.jsonwebtoken.security.SignatureException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.stereotype.Component
+import java.time.Instant
+import java.util.Date
+import javax.crypto.SecretKey
+
+private val logger = KotlinLogging.logger {  }
+
+@Component
+class JwtTokenProvider(
+    @Value("\${jwt.key}")
+    private val key: String,
+
+    @Value("\${jwt.access-token-expire-time}")
+    private val accessTokenExpireTime: Long,
+
+    @Value("\${jwt.refresh-token-expire-time}")
+    private val refreshTokenExpireTime: Long
+) {
+    fun generateAccessJwt(
+        userId: Long,
+        roles: Collection<GrantedAuthority?>?
+    ): String {
+        val authorities = roles?.map { it?.authority }
+        val key = getKey()
+        val now = Instant.now()
+
+        return Jwts.builder()
+            .subject(userId.toString())
+            .claim("auth", authorities)
+            .issuedAt(Date(now.toEpochMilli()))
+            .expiration(Date(now.plusMillis(accessTokenExpireTime).toEpochMilli()))
+            .signWith(key, Jwts.SIG.HS256)
+            .compact()
+    }
+
+    fun generateRefreshJwt(userId: Long): String {
+        val key = getKey()
+        val now = Instant.now()
+
+        return Jwts.builder()
+            .subject(userId.toString())
+            .issuedAt(Date(now.toEpochMilli()))
+            .expiration(Date(now.plusMillis(refreshTokenExpireTime).toEpochMilli()))
+            .signWith(key, Jwts.SIG.HS256)
+            .compact()
+    }
+
+    fun validateJwt(jwt: String?): Boolean {
+        try {
+            Jwts.parser().verifyWith(getKey()).build().parseSignedClaims(jwt)
+            return true
+        } catch (e: ExpiredJwtException) {
+            logger.warn { "JWT가 만료되었습니다." }
+            throw JwtException("JWT가 만료되었습니다.")
+        } catch (e: SignatureException) {
+            logger.warn { "JWT 서명 검증에 실패했습니다." }
+            throw JwtException("JWT 서명 검증에 실패했습니다.")
+        }
+    }
+
+    fun getAuthentication(jwt: String): Authentication {
+        val claims = getClaims(jwt)
+        val userId = claims.subject.toLong()
+        val authorities = claims["auth"] as? List<*>
+
+        return UsernamePasswordAuthenticationToken(userId,
+            null,
+            authorities?.filterIsInstance<String>()
+                ?.map { SimpleGrantedAuthority(it) })
+    }
+
+    private fun getKey(): SecretKey {
+        return Keys.hmacShaKeyFor(this.key.toByteArray())
+    }
+
+    fun getClaims(jwt: String): Claims {
+        return Jwts.parser().verifyWith(getKey()).build().parseSignedClaims(jwt).payload
+    }
+}

--- a/src/main/kotlin/com/zunza/gongsamo/security/jwt/TokenUtil.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/security/jwt/TokenUtil.kt
@@ -1,0 +1,7 @@
+package com.zunza.gongsamo.security.jwt
+
+private const val TOKEN_PREFIX = "Bearer "
+
+fun String?.extractJwtFromBearerHeader(): String? =
+    this?.takeIf { it.startsWith(TOKEN_PREFIX) }
+        ?.substring(TOKEN_PREFIX.length)

--- a/src/main/kotlin/com/zunza/gongsamo/security/user/CustomUserDetails.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/security/user/CustomUserDetails.kt
@@ -1,0 +1,38 @@
+package com.zunza.gongsamo.security.user
+
+import com.zunza.gongsamo.user.entity.User
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+
+class CustomUserDetails(
+    private val user: User
+) : UserDetails {
+
+    override fun getAuthorities(): Collection<GrantedAuthority?>? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getPassword(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getUsername(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun isAccountNonExpired(): Boolean {
+        return true
+    }
+
+    override fun isAccountNonLocked(): Boolean {
+        return true
+    }
+
+    override fun isCredentialsNonExpired(): Boolean {
+        return true
+    }
+
+    override fun isEnabled(): Boolean {
+        return true
+    }
+}

--- a/src/main/kotlin/com/zunza/gongsamo/security/user/CustomUserDetailsService.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/security/user/CustomUserDetailsService.kt
@@ -1,0 +1,24 @@
+package com.zunza.gongsamo.security.user
+
+import com.zunza.gongsamo.user.repository.UserRepository
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import org.springframework.stereotype.Component
+
+@Component
+class CustomUserDetailsService(
+    private val userRepository: UserRepository
+) : UserDetailsService {
+
+    override fun loadUserByUsername(username: String?): UserDetails? {
+        if (username.isNullOrBlank()) {
+            throw UsernameNotFoundException("사용자 이름은 null 또는 공백일 수 없습니다.")
+        }
+
+        val user = userRepository.findByEmail(username)
+            ?: throw UsernameNotFoundException("사용자를 찾을 수 없습니다: $username")
+
+        return CustomUserDetails(user)
+    }
+}


### PR DESCRIPTION
- JwtTokenProvider 추가:
  - Access Token 및 Refresh Token 생성 기능을 구현했습니다.
  - JWT의 유효성 검증(만료, 서명 등) 로직을 추가했습니다.
  - JWT에서 Authentication 객체를 추출하는 기능을 구현했습니다.

- JwtAuthenticationFilter 추가:
  - OncePerRequestFilter를 상속받아 HTTP 요청 헤더(Authorization)에서 JWT를 추출합니다.
  - 추출된 JWT의 유효성을 JwtTokenProvider를 통해 검증하고, 유효한 경우 SecurityContextHolder에 인증 정보를 저장합니다.

- CustomUserDetailsService 및 CustomUserDetails 구현:
  - Spring Security의 UserDetailsService를 구현하여 데이터베이스에서 사용자 정보를 조회합니다.