### PR TITLE
feat: JWT 예외 처리를 위한 필터 추가

### DIFF
--- a/src/main/kotlin/com/zunza/gongsamo/security/jwt/JwtExceptionFilter.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/security/jwt/JwtExceptionFilter.kt
@@ -1,0 +1,36 @@
+package com.zunza.gongsamo.security.jwt
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.zunza.gongsamo.common.ApiResponse
+import com.zunza.gongsamo.common.ErrorResponse
+import io.jsonwebtoken.JwtException
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.filter.OncePerRequestFilter
+
+class JwtExceptionFilter(
+    private val objectMapper: ObjectMapper
+) : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        try {
+            filterChain.doFilter(request, response)
+        } catch (e: JwtException) {
+            val errorResponse = ErrorResponse(e.message)
+            val apiResponse = ApiResponse(errorResponse, HttpStatus.UNAUTHORIZED.value())
+
+            response.status = HttpStatus.UNAUTHORIZED.value()
+            response.contentType = MediaType.APPLICATION_JSON.toString()
+            response.characterEncoding = "UTF-8"
+
+            objectMapper.writeValue(response.writer, apiResponse)
+        }
+    }
+}


### PR DESCRIPTION
- JwtAuthenticationFilter에서 발생하는 인증 예외(JwtException)를 처리하기 위해 JwtExceptionFilter를 추가했습니다.
- Spring Security filter chain 단에서 발생하는 예외를 감지하여 ApiResponse 형식의 401 에러를 반환하도록 구현했습니다.