### PR TITLE
feat: JPA Auditing을 이용한 엔티티 생성/수정 시간 자동화

### DIFF
--- a/src/main/kotlin/com/zunza/gongsamo/common/BaseEntity.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/common/BaseEntity.kt
@@ -1,0 +1,21 @@
+package com.zunza.gongsamo.common
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+class BaseEntity(
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+)

--- a/src/main/kotlin/com/zunza/gongsamo/config/JpaAuditConfig.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/config/JpaAuditConfig.kt
@@ -1,0 +1,9 @@
+package com.zunza.gongsamo.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+
+@Configuration
+@EnableJpaAuditing
+class JpaAuditConfig {
+}


### PR DESCRIPTION
- 모든 엔티티에서 공통으로 사용될 생성 시간(createdAt)과 수정 시간(updatedAt)을 자동으로 관리하기 위해 BaseEntity를 추가하고, JpaAuditConfig를 설정했습니다.