### PR TITLE
feat: 회원가입 시 이메일 및 닉네임 중복 확인 기능 구현

### DIFF
--- a/src/main/kotlin/com/zunza/gongsamo/user/controller/AuthController.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/user/controller/AuthController.kt
@@ -1,0 +1,26 @@
+package com.zunza.gongsamo.user.controller
+
+import com.zunza.gongsamo.user.dto.EmailAvailableResponse
+import com.zunza.gongsamo.user.dto.NicknameAvailableResponse
+import com.zunza.gongsamo.user.service.AuthService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class AuthController(
+    private val authService: AuthService
+) {
+    @GetMapping("/api/auth/signup/email/validation")
+    fun checkEmailDuplication(
+        @RequestParam email: String
+    ): ResponseEntity<EmailAvailableResponse> =
+        ResponseEntity.ok(authService.isEmailAvailable(email))
+
+    @GetMapping("/api/auth/signup/nickname/validation")
+    fun checkNicknameDuplication(
+        @RequestParam nickname: String
+    ): ResponseEntity<NicknameAvailableResponse> =
+        ResponseEntity.ok(authService.isNicknameAvailable(nickname))
+}

--- a/src/main/kotlin/com/zunza/gongsamo/user/dto/AvailableResponse.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/user/dto/AvailableResponse.kt
@@ -1,0 +1,9 @@
+package com.zunza.gongsamo.user.dto
+
+data class EmailAvailableResponse(
+    val isAvailable: Boolean
+)
+
+data class NicknameAvailableResponse(
+    val isAvailable: Boolean
+)

--- a/src/main/kotlin/com/zunza/gongsamo/user/entity/User.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/user/entity/User.kt
@@ -1,0 +1,25 @@
+package com.zunza.gongsamo.user.entity
+
+import com.zunza.gongsamo.common.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+
+
+@Entity
+class User(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @Column(nullable = false, unique = true)
+    val email: String,
+
+    @Column(nullable = false, unique = true)
+    val nickname: String,
+
+    @Column(nullable = false)
+    val password: String
+) : BaseEntity()

--- a/src/main/kotlin/com/zunza/gongsamo/user/exception/UserNotFoundException.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/user/exception/UserNotFoundException.kt
@@ -1,0 +1,16 @@
+package com.zunza.gongsamo.user.exception
+
+import com.zunza.gongsamo.common.CustomException
+import org.springframework.http.HttpStatus
+
+class UserNotFoundException(
+    id: Long
+) : CustomException(MESSAGE + id) {
+
+    companion object {
+        private const val MESSAGE = "사용자를 찾을 수 업습니다: "
+    }
+
+    override fun getStatusCode() =
+        HttpStatus.NOT_FOUND.value()
+}

--- a/src/main/kotlin/com/zunza/gongsamo/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/user/repository/UserRepository.kt
@@ -1,0 +1,12 @@
+package com.zunza.gongsamo.user.repository
+
+import com.zunza.gongsamo.user.entity.User
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface UserRepository : JpaRepository<User, Long> {
+    fun findByEmail(email: String): User?
+    fun existsByEmail(email: String): Boolean
+    fun existsByNickname(nickname: String): Boolean
+}

--- a/src/main/kotlin/com/zunza/gongsamo/user/service/AuthService.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/user/service/AuthService.kt
@@ -1,0 +1,46 @@
+package com.zunza.gongsamo.user.service
+
+import com.zunza.gongsamo.user.dto.EmailAvailableResponse
+import com.zunza.gongsamo.user.dto.NicknameAvailableResponse
+import com.zunza.gongsamo.user.repository.UserRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Service
+
+private val logger = KotlinLogging.logger {  }
+
+@Service
+class AuthService(
+    private val userRepository: UserRepository
+) {
+    fun isEmailAvailable(email: String): EmailAvailableResponse {
+        validateEmailFormat(email)
+        return when (userRepository.existsByEmail(email)) {
+            true -> EmailAvailableResponse(false)
+            false -> EmailAvailableResponse(true)
+        }
+    }
+
+    fun isNicknameAvailable(nickname: String): NicknameAvailableResponse {
+        validateNicknameFormat(nickname)
+        return when (userRepository.existsByNickname(nickname)) {
+            true -> NicknameAvailableResponse(false)
+            false -> NicknameAvailableResponse(true)
+        }
+    }
+
+    private fun validateEmailFormat(email: String) {
+        val emailRegex = Regex("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$")
+        if (!emailRegex.matches(email)) {
+            logger.warn { "잘못된 이메일 형식입니다: $email" }
+            throw IllegalArgumentException("잘못된 이메일 형식입니다.")
+        }
+    }
+
+    private fun validateNicknameFormat(nickname: String) {
+        val nicknameRegex = Regex("^(?=.*[가-힣a-zA-Z])[가-힣a-zA-Z0-9]{2,12}$")
+        if (!nicknameRegex.matches(nickname)) {
+            logger.warn { "잘못된 닉네임 형식입니다: $nickname" }
+            throw IllegalArgumentException("잘못된 닉네임 형식입니다.")
+        }
+    }
+}


### PR DESCRIPTION
- User 엔티티 및 Repository 추가: 사용자 정보를 관리하기 위한 User 엔티티와 UserRepository를 생성했습니다.
- 중복 확인 로직 구현: AuthService에 이메일/닉네임 형식의 유효성을 검사하고, DB에 중복된 값이 있는지 확인하는 로직을 추가했습니다.
- API 엔드포인트 추가: AuthController에 다음 두 개의 API를 추가하여 클라이언트가 중복 여부를 확인할 수 있도록 구현했습니다.
  - GET /api/auth/signup/email/validation
  - GET /api/auth/signup/nickname/validation