### PR TITLE
feat: JWT 기반 로그인 및 로그아웃 구현

### DIFF
--- a/src/main/kotlin/com/zunza/gongsamo/security/user/CustomUserDetails.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/security/user/CustomUserDetails.kt
@@ -8,16 +8,22 @@ class CustomUserDetails(
     private val user: User
 ) : UserDetails {
 
+    val userId: Long
+        get() = user.id
+
+    val nickname: String
+        get() = user.nickname
+
     override fun getAuthorities(): Collection<GrantedAuthority?>? {
-        TODO("Not yet implemented")
+        return mutableListOf(GrantedAuthority { "ROLE_USER" })
     }
 
     override fun getPassword(): String? {
-        TODO("Not yet implemented")
+        return user.password
     }
 
     override fun getUsername(): String? {
-        TODO("Not yet implemented")
+        return user.email
     }
 
     override fun isAccountNonExpired(): Boolean {

--- a/src/main/kotlin/com/zunza/gongsamo/user/controller/AuthController.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/user/controller/AuthController.kt
@@ -2,17 +2,23 @@ package com.zunza.gongsamo.user.controller
 
 import com.zunza.gongsamo.common.ApiResponse
 import com.zunza.gongsamo.user.dto.EmailAvailableResponse
+import com.zunza.gongsamo.user.dto.LoginRequest
+import com.zunza.gongsamo.user.dto.LoginResponse
 import com.zunza.gongsamo.user.dto.NicknameAvailableResponse
 import com.zunza.gongsamo.user.dto.SignupRequest
 import com.zunza.gongsamo.user.service.AuthService
 import jakarta.validation.Valid
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseCookie
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.time.Duration
 
 @RestController
 class AuthController(
@@ -37,6 +43,43 @@ class AuthController(
         authService.signup(signupRequest)
         return ResponseEntity
             .status(HttpStatus.CREATED)
+            .build()
+    }
+
+    @PostMapping("/api/auth/login")
+    fun login(
+        @RequestBody loginRequest: LoginRequest
+    ): ResponseEntity<LoginResponse> {
+        val loginResultMap: Map<String, String> = authService.login(loginRequest)
+        val nickname = loginResultMap["nickname"]!!
+        val accessJwt = loginResultMap["accessJwt"]!!
+        val refreshJwt = loginResultMap["refreshJwt"]!!
+        val responseCookie = buildResponseCookie(refreshJwt, Duration.ofDays(7))
+
+        return ResponseEntity.ok()
+            .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+            .body(LoginResponse(nickname, accessJwt))
+    }
+
+    @PostMapping("/api/auth/logout")
+    fun logout(
+        @AuthenticationPrincipal userId: Long
+    ): ResponseEntity<ApiResponse<Unit>> {
+        authService.logout(userId)
+        return ResponseEntity.ok()
+            .header(HttpHeaders.SET_COOKIE, buildResponseCookie().toString())
+            .build()
+    }
+
+    private fun buildResponseCookie(
+        value: String = "",
+        maxAge: Duration = Duration.ZERO
+    ): ResponseCookie {
+        return ResponseCookie.from("refreshToken", value)
+            .httpOnly(true)
+            .secure(false)
+            .path("/")
+            .maxAge(maxAge)
             .build()
     }
 }

--- a/src/main/kotlin/com/zunza/gongsamo/user/dto/LoginRequest.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/user/dto/LoginRequest.kt
@@ -1,0 +1,6 @@
+package com.zunza.gongsamo.user.dto
+
+data class LoginRequest(
+    val email: String,
+    val password: String
+)

--- a/src/main/kotlin/com/zunza/gongsamo/user/dto/LoginResponse.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/user/dto/LoginResponse.kt
@@ -1,0 +1,6 @@
+package com.zunza.gongsamo.user.dto
+
+data class LoginResponse(
+    val nickname: String,
+    val jwt: String
+)

--- a/src/main/kotlin/com/zunza/gongsamo/user/exception/LoginFailedException.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/user/exception/LoginFailedException.kt
@@ -1,0 +1,13 @@
+package com.zunza.gongsamo.user.exception
+
+import com.zunza.gongsamo.common.CustomException
+import jakarta.servlet.http.HttpServletResponse.*
+
+class LoginFailedException : CustomException(MESSAGE) {
+
+    companion object {
+        private const val MESSAGE = "아이디 또는 비밀번호를 확인해 주세요."
+    }
+
+    override fun getStatusCode() = SC_UNAUTHORIZED
+}

--- a/src/main/kotlin/com/zunza/gongsamo/user/repository/RefreshJwtRepository.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/user/repository/RefreshJwtRepository.kt
@@ -1,0 +1,32 @@
+package com.zunza.gongsamo.user.repository
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+
+@Component
+class RefreshJwtRepository(
+    @Value("\${jwt.refresh-token-expire-time}")
+    private val ttl: Long,
+    private val stringRedisTemplate: StringRedisTemplate
+) {
+    companion object {
+        private const val REFRESH_TOKEN_KEY_PREFIX = "RT:"
+    }
+
+    fun save(userId: Long, refreshJwt: String) {
+        stringRedisTemplate
+            .opsForValue()
+            .set(
+                REFRESH_TOKEN_KEY_PREFIX + userId,
+                refreshJwt,
+                ttl,
+                TimeUnit.MILLISECONDS
+            )
+    }
+
+    fun delete(userId: Long) {
+        stringRedisTemplate.delete(REFRESH_TOKEN_KEY_PREFIX + userId)
+    }
+}


### PR DESCRIPTION
사용자 인증 및 토큰 발급/삭제를 처리하는 로그인/로그아웃 기능을 구현했습니다.

- 로그인 시 Access Token과 Refresh Token을 발급합니다.
- Refresh Token은 redis에 저장합니다.
- Refresh Token은 HttpOnly 쿠키를 통해 안전하게 전달/관리됩니다.
- Spring Security의 AuthenticationManager를 통합하여 사용자 인증을 처리합니다.
- 로그아웃 시 redis에서 삭제하고 Refresh Token 쿠키를 즉시 만료시킵니다.