### PR TITLE
feat: 커서 기반 페이지네이션을 적용한 게시글 목록 조회 구현

### DIFF
--- a/src/main/kotlin/com/zunza/gongsamo/post/constant/PostStatus.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/constant/PostStatus.kt
@@ -1,0 +1,8 @@
+package com.zunza.gongsamo.post.constant
+
+enum class PostStatus {
+    RECRUITING, // 모집중
+    RECRUITMENT_CLOSED, // 모집완료
+    TRANSACTION_COMPLETED, // 거래완료
+    CANCELLED // 취소됨
+}

--- a/src/main/kotlin/com/zunza/gongsamo/post/constant/SettlementType.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/constant/SettlementType.kt
@@ -1,0 +1,19 @@
+package com.zunza.gongsamo.post.constant
+
+import com.fasterxml.jackson.annotation.JsonCreator
+
+enum class SettlementType(
+    val value: String
+) {
+    FACE_TO_FACE("만나서 정산"),
+    SAFE_PAYMENT("안전 정산");
+
+    companion object {
+        @JsonCreator
+        @JvmStatic
+        fun from(value: String): SettlementType {
+            return entries.find { it.value == value }
+                ?: throw IllegalArgumentException("잘못된 정산 방법입니다.")
+        }
+    }
+}

--- a/src/main/kotlin/com/zunza/gongsamo/post/constant/SortType.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/constant/SortType.kt
@@ -1,0 +1,16 @@
+package com.zunza.gongsamo.post.constant
+
+enum class SortType(
+    val value: String
+) {
+    LATEST("최신순"),
+    DEADLINE_ASC("마감 임박순"),
+    DEADLINE_DESC("마감 여유순");
+
+    companion object {
+        fun from(value: String): SortType {
+            return entries.find { it.value == value }
+                ?: throw IllegalArgumentException("존재하지 않는 정렬 방식입니다.")
+        }
+    }
+}

--- a/src/main/kotlin/com/zunza/gongsamo/post/controller/PostController.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/controller/PostController.kt
@@ -1,0 +1,49 @@
+package com.zunza.gongsamo.post.controller
+
+import com.zunza.gongsamo.common.ApiResponse
+import com.zunza.gongsamo.post.constant.SortType
+import com.zunza.gongsamo.post.dto.CreatePostRequest
+import com.zunza.gongsamo.post.dto.LocationFilter
+import com.zunza.gongsamo.post.dto.PostCursor
+import com.zunza.gongsamo.post.dto.PostPageResponse
+import com.zunza.gongsamo.post.service.PostService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDateTime
+
+@RestController
+class PostController(
+    private val postService: PostService
+) {
+    @PostMapping("/api/posts")
+    fun createPost(
+        @AuthenticationPrincipal userId: Long,
+        @Valid @RequestBody createPostRequest: CreatePostRequest
+    ): ResponseEntity<ApiResponse<Unit>> {
+        postService.createPost(userId, createPostRequest)
+        return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+
+    @GetMapping("/api/posts")
+    fun getPostPage(
+        @ModelAttribute locationFilter: LocationFilter,
+        @RequestParam sortType: SortType = SortType.LATEST,
+        @RequestParam size: Int = 15,
+        @ModelAttribute postCursor: PostCursor
+    ): ResponseEntity<PostPageResponse> {
+        return ResponseEntity.ok(postService.getPostPage(
+            locationFilter,
+            sortType,
+            size,
+            postCursor
+            ))
+    }
+}

--- a/src/main/kotlin/com/zunza/gongsamo/post/converter/SortTypeConverter.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/converter/SortTypeConverter.kt
@@ -1,0 +1,12 @@
+package com.zunza.gongsamo.post.converter
+
+import com.zunza.gongsamo.post.constant.SortType
+import org.springframework.core.convert.converter.Converter
+import org.springframework.stereotype.Component
+
+@Component
+class SortTypeConverter : Converter<String, SortType> {
+    override fun convert(source: String): SortType? {
+        return SortType.from(source)
+    }
+}

--- a/src/main/kotlin/com/zunza/gongsamo/post/dto/CreatePostRequest.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/dto/CreatePostRequest.kt
@@ -1,0 +1,43 @@
+package com.zunza.gongsamo.post.dto
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.zunza.gongsamo.post.entity.SettlementType
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+data class CreatePostRequest(
+    @field: NotBlank(message = "제목을 입력해 주세요.")
+    val title: String?,
+
+    @field: NotBlank(message = "상품 설명을 입력해 주세요.")
+    val description: String?,
+
+    val productImageUrl: String? = null,
+
+    val productLink: String? = null,
+
+    @field: NotNull(message = "상품 가격을을 입력해 주세요.")
+    val productPrice: BigDecimal?,
+
+    @field: NotNull(message = "거래 희망 장소를 입력해 주세요.")
+    val meetingLocation: MeetingLocationRequest?,
+
+    @field: NotNull(message = "모집 인원을 설정해 주세요.")
+    val maxParticipants: Int?,
+
+    @field: NotNull(message = "모집 기간을 설정해 주세요.")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
+    val recruitmentDeadline: LocalDateTime?,
+
+    @field: NotNull(message = "정산 방법을 선택해 주세요.")
+    val settlementType: SettlementType?
+)
+
+data class MeetingLocationRequest(
+    val placeName: String,
+    val addressName: String,
+    val x: String,
+    val y: String
+)

--- a/src/main/kotlin/com/zunza/gongsamo/post/dto/LocationFilter.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/dto/LocationFilter.kt
@@ -1,0 +1,8 @@
+package com.zunza.gongsamo.post.dto
+
+data class LocationFilter(
+    val sido: String,
+    val sigungu: String?,
+    val dong: String?
+)
+

--- a/src/main/kotlin/com/zunza/gongsamo/post/dto/PostCursor.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/dto/PostCursor.kt
@@ -1,0 +1,12 @@
+package com.zunza.gongsamo.post.dto
+
+import org.springframework.format.annotation.DateTimeFormat
+import java.time.LocalDateTime
+
+data class PostCursor(
+    val postId: Long? = null,
+
+//    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @field: DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    val datetime: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/zunza/gongsamo/post/dto/PostPageResponse.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/dto/PostPageResponse.kt
@@ -1,0 +1,27 @@
+package com.zunza.gongsamo.post.dto
+
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+data class PostPageResponse(
+    val postPreviews: List<PostPreview> = emptyList(),
+    val nextCursor: NextCursor? = null,
+    val hasMore: Boolean = false
+)
+
+data class PostPreview(
+    val id: Long = 0,
+    val title: String = "",
+    val meetingPlace: String = "",
+    val productPrice: BigDecimal = BigDecimal.ZERO,
+    val productImageUrl: String? = null,
+    val maxParticipants: Int = 0,
+    val currentParticipants: Long = 0,
+    val recruitmentDeadline: LocalDateTime = LocalDateTime.MIN,
+    val createdAt: LocalDateTime = LocalDateTime.MIN
+)
+
+data class NextCursor(
+    val postId: Long? = null,
+    val datetime: LocalDateTime? = null
+)

--- a/src/main/kotlin/com/zunza/gongsamo/post/entity/Participant.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/entity/Participant.kt
@@ -1,0 +1,40 @@
+package com.zunza.gongsamo.post.entity
+
+import com.zunza.gongsamo.common.BaseEntity
+import com.zunza.gongsamo.user.entity.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+
+@Entity
+class Participant(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    val post: Post,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    val user: User,
+
+    @Column(nullable = false)
+    val isHost: Boolean = false,
+
+    @Column(nullable = false)
+    var settlementConfirmed: Boolean = false
+) : BaseEntity() {
+
+    companion object {
+        fun createOf(post: Post, user: User, isHost: Boolean = false): Participant {
+            return Participant(post = post, user = user, isHost = isHost)
+        }
+    }
+}

--- a/src/main/kotlin/com/zunza/gongsamo/post/entity/Post.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/entity/Post.kt
@@ -1,0 +1,143 @@
+package com.zunza.gongsamo.post.entity
+
+import com.zunza.gongsamo.common.BaseEntity
+import com.zunza.gongsamo.post.constant.PostStatus
+import com.zunza.gongsamo.post.constant.SettlementType
+import com.zunza.gongsamo.post.dto.CreatePostRequest
+import com.zunza.gongsamo.post.dto.MeetingLocationRequest
+import com.zunza.gongsamo.user.entity.User
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.Embedded
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.Lob
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@Entity
+class Post(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "host_id", nullable = false)
+    val host: User,
+
+    @Column(nullable = false, length = 200)
+    var title: String,
+
+    @Lob
+    @Column(nullable = false, columnDefinition = "TEXT")
+    var description: String,
+
+    @Column(length = 500)
+    var productImageUrl: String? = null,
+
+    @Column(length = 1000)
+    var productLink: String? = null,
+
+    val productPrice: BigDecimal,
+
+    @Embedded
+    val meetingLocation: MeetingLocation,
+
+    @Column(nullable = false)
+    val maxParticipants: Int,
+
+    @Column(nullable = false)
+    val recruitmentDeadline: LocalDateTime,
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    val settlementType: SettlementType,
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    val status: PostStatus,
+
+    @OneToMany(
+        mappedBy = "post",
+        cascade = [CascadeType.ALL],
+        orphanRemoval = true)
+    val participants: MutableList<Participant> = mutableListOf(),
+) : BaseEntity() {
+
+    companion object {
+        fun createOf(
+            user: User,
+            createPostRequest: CreatePostRequest,
+            meetingLocation: MeetingLocation
+        ): Post {
+            return Post(
+                host = user,
+                title = createPostRequest.title!!,
+                description = createPostRequest.description!!,
+                productImageUrl = createPostRequest.productImageUrl,
+                productLink = createPostRequest.productLink,
+                productPrice = createPostRequest.productPrice!!,
+                meetingLocation = meetingLocation,
+                maxParticipants = createPostRequest.maxParticipants!!,
+                recruitmentDeadline = createPostRequest.recruitmentDeadline!!,
+                settlementType = createPostRequest.settlementType!!,
+                status = PostStatus.RECRUITING
+            )
+        }
+    }
+
+    fun addParticipant(participant: Participant) {
+        this.participants.add(participant)
+    }
+}
+
+@Embeddable
+class MeetingLocation(
+    @Column(length = 50)
+    val placeName: String,
+    @Column(length = 8)
+    val sido: String,
+    @Column(length = 8)
+    val sigungu: String,
+    @Column(length = 8)
+    val dong: String,
+    @Column(length = 30)
+    val x: String,
+    @Column(length = 30)
+    val y: String
+) {
+    companion object {
+        fun createFrom(
+            request: MeetingLocationRequest
+        ): MeetingLocation {
+            val (sido, sigungu, dong) =
+                request.addressName
+                    .split(" ")
+                    .let { parts ->
+                        Triple(
+                            parts.getOrNull(0) ?: "",
+                            parts.getOrNull(1) ?: "",
+                            parts.getOrNull(2) ?: ""
+                        )
+                    }
+
+            return MeetingLocation(
+                request.placeName,
+                sido,
+                sigungu,
+                dong,
+                request.x,
+                request.y
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/zunza/gongsamo/post/repository/ParticipantRepository.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/repository/ParticipantRepository.kt
@@ -1,0 +1,9 @@
+package com.zunza.gongsamo.post.repository
+
+import com.zunza.gongsamo.post.entity.Participant
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ParticipantRepository : JpaRepository<Participant, Long>{
+}

--- a/src/main/kotlin/com/zunza/gongsamo/post/repository/PostRepository.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/repository/PostRepository.kt
@@ -1,0 +1,10 @@
+package com.zunza.gongsamo.post.repository
+
+import com.zunza.gongsamo.post.entity.Post
+import com.zunza.gongsamo.post.repository.querydsl.CustomPostRepository
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface PostRepository : JpaRepository<Post, Long>, CustomPostRepository {
+}

--- a/src/main/kotlin/com/zunza/gongsamo/post/repository/querydsl/CustomPostRepository.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/repository/querydsl/CustomPostRepository.kt
@@ -1,0 +1,15 @@
+package com.zunza.gongsamo.post.repository.querydsl
+
+import com.zunza.gongsamo.post.constant.SortType
+import com.zunza.gongsamo.post.dto.LocationFilter
+import com.zunza.gongsamo.post.dto.PostCursor
+import com.zunza.gongsamo.post.dto.PostPageResponse
+
+interface CustomPostRepository {
+    fun findPageByCursor(
+        locationFilter: LocationFilter,
+        sortType: SortType,
+        size: Int,
+        postCursor: PostCursor
+    ): PostPageResponse
+}

--- a/src/main/kotlin/com/zunza/gongsamo/post/repository/querydsl/CustomPostRepositoryImpl.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/repository/querydsl/CustomPostRepositoryImpl.kt
@@ -1,0 +1,140 @@
+package com.zunza.gongsamo.post.repository.querydsl
+
+import com.querydsl.core.types.Expression
+import com.querydsl.core.types.OrderSpecifier
+import com.querydsl.core.types.Projections
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.zunza.gongsamo.post.constant.SortType
+import com.zunza.gongsamo.post.dto.LocationFilter
+import com.zunza.gongsamo.post.dto.NextCursor
+import com.zunza.gongsamo.post.dto.PostCursor
+import com.zunza.gongsamo.post.dto.PostPageResponse
+import com.zunza.gongsamo.post.dto.PostPreview
+import com.zunza.gongsamo.post.entity.QParticipant
+import com.zunza.gongsamo.post.entity.QPost
+import org.springframework.stereotype.Component
+
+
+@Component
+class CustomPostRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory,
+    private val post: QPost = QPost.post,
+    private val participant: QParticipant = QParticipant.participant
+) : CustomPostRepository {
+    override fun findPageByCursor(
+        locationFilter: LocationFilter,
+        sortType: SortType,
+        size: Int,
+        postCursor: PostCursor
+    ): PostPageResponse {
+        val result = jpaQueryFactory.select(
+            Projections.constructor(
+                PostPreview::class.java,
+                post.id,
+                post.title,
+                post.meetingLocation.placeName,
+                post.productPrice,
+                post.productImageUrl,
+                post.maxParticipants,
+                participant.id.countDistinct(),
+                post.recruitmentDeadline,
+                post.createdAt
+            )
+        )
+            .from(post)
+            .leftJoin(post.participants, participant)
+            .where(
+                locationCondition(locationFilter),
+                cursorCondition(sortType, postCursor)
+            )
+            .orderBy(*buildOrderByExpressions(sortType))
+            .groupBy(*buildGroupByExpressions(sortType))
+            .limit(size + 1L)
+            .fetch()
+            .toMutableList()
+
+        val nextCursor = getNextCursor(sortType, size, result)
+        val hasMore = result.size > size
+        if (result.size > size) result.removeLast()
+
+        return PostPageResponse(result, nextCursor, hasMore)
+    }
+
+    private fun locationCondition(
+        locationFilter: LocationFilter
+    ): BooleanExpression? {
+        if (locationFilter.sido == "전체") return null
+
+        var condition: BooleanExpression =
+            post.meetingLocation.region1DepthName
+            .eq(locationFilter.sido)
+
+        locationFilter.sigungu?.let { region2 ->
+            condition = condition.and(
+                post.meetingLocation.region2DepthName
+                    .eq(locationFilter.sigungu)
+            )
+        }
+
+        locationFilter.dong?.let { region3 ->
+            condition = condition.and(
+                post.meetingLocation.region3DepthName
+                    .eq(locationFilter.dong)
+            )
+        }
+
+        return condition
+    }
+
+    private fun cursorCondition(
+        sortType: SortType,
+        postCursor: PostCursor
+    ): BooleanExpression? {
+        if (postCursor.postId == null) return null
+
+        return when (sortType) {
+            SortType.LATEST -> post.createdAt.lt(postCursor.datetime)
+                .or(post.createdAt.eq(postCursor.datetime)
+                    .and(post.id.lt(postCursor.postId)))
+
+            SortType.DEADLINE_ASC -> post.recruitmentDeadline.gt(postCursor.datetime)
+                .or(post.recruitmentDeadline.eq(postCursor.datetime)
+                    .and(post.id.gt(postCursor.postId)))
+
+            SortType.DEADLINE_DESC -> post.recruitmentDeadline.lt(postCursor.datetime)
+                .or(post.recruitmentDeadline.eq(postCursor.datetime)
+                    .and(post.id.lt(postCursor.postId)))
+        }
+    }
+
+    private fun buildOrderByExpressions(sortType: SortType): Array<OrderSpecifier<*>> {
+        return when (sortType) {
+            SortType.LATEST -> arrayOf(post.createdAt.desc(), post.id.desc())
+            SortType.DEADLINE_ASC -> arrayOf(post.recruitmentDeadline.asc(), post.id.asc())
+            SortType.DEADLINE_DESC -> arrayOf(post.recruitmentDeadline.desc(), post.id.desc())
+        }
+    }
+
+    private fun buildGroupByExpressions(sortType: SortType): Array<Expression<*>> {
+        return when (sortType) {
+            SortType.LATEST -> arrayOf(post.createdAt, post.id)
+            SortType.DEADLINE_ASC,
+            SortType.DEADLINE_DESC -> arrayOf(post.recruitmentDeadline, post.id)
+        }
+    }
+
+    private fun getNextCursor(
+        sortType: SortType,
+        size: Int,
+        result: MutableList<PostPreview>
+    ): NextCursor {
+        return when {
+            result.size < size -> NextCursor()
+            else -> when (sortType) {
+                SortType.LATEST -> NextCursor(result.last().id, result.last().createdAt)
+                else -> NextCursor(result.last().id, result.last().recruitmentDeadline)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/zunza/gongsamo/post/service/PostService.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/service/PostService.kt
@@ -1,0 +1,53 @@
+package com.zunza.gongsamo.post.service
+
+import com.zunza.gongsamo.post.constant.SortType
+import com.zunza.gongsamo.post.dto.CreatePostRequest
+import com.zunza.gongsamo.post.dto.LocationFilter
+import com.zunza.gongsamo.post.dto.PostCursor
+import com.zunza.gongsamo.post.dto.PostPageResponse
+import com.zunza.gongsamo.post.entity.MeetingLocation
+import com.zunza.gongsamo.post.entity.Participant
+import com.zunza.gongsamo.post.entity.Post
+import com.zunza.gongsamo.post.repository.PostRepository
+import com.zunza.gongsamo.user.exception.UserNotFoundException
+import com.zunza.gongsamo.user.repository.UserRepository
+import jakarta.transaction.Transactional
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+
+@Service
+class PostService(
+    private val postRepository: PostRepository,
+    private val userRepository: UserRepository,
+) {
+    @Transactional
+    fun createPost(
+        userId: Long,
+        createPostRequest: CreatePostRequest
+    ) {
+        val user = userRepository.findByIdOrNull(userId)
+            ?: throw UserNotFoundException(userId)
+
+        val meetingLocationRequest = requireNotNull(createPostRequest.meetingLocation)
+        val meetingLocation = MeetingLocation.createFrom(meetingLocationRequest)
+        val post = Post.createOf(user, createPostRequest, meetingLocation)
+        val participant = Participant.createOf(post, user, true)
+        post.addParticipant(participant)
+        postRepository.save(post)
+    }
+
+    fun getPostPage(
+        locationFilter: LocationFilter,
+        sortType: SortType,
+        size: Int,
+        postCursor: PostCursor
+    ): PostPageResponse {
+        return postRepository.findPageByCursor(
+            locationFilter,
+            sortType,
+            size,
+            postCursor
+        )
+    }
+}


### PR DESCRIPTION
- QueryDSL을 사용하여 게시글 목록을 조회하는 API를 구현했습니다.
- 성능 향상을 위해 기존의 offset 방식이 아닌 커서 기반 페이지네이션을 적용했습니다.
- 또한, 지역별 필터링과 최신순/마감순 등 다양한 정렬 조건을 동적으로 처리하도록 구현했습니다.