### PR TITLE
feat: 게시글 상세 조회 구현

### DIFF
--- a/src/main/kotlin/com/zunza/gongsamo/post/constant/SettlementType.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/constant/SettlementType.kt
@@ -1,8 +1,10 @@
 package com.zunza.gongsamo.post.constant
 
 import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
 
 enum class SettlementType(
+    @JsonValue
     val value: String
 ) {
     FACE_TO_FACE("만나서 정산"),

--- a/src/main/kotlin/com/zunza/gongsamo/post/controller/PostController.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/controller/PostController.kt
@@ -5,6 +5,7 @@ import com.zunza.gongsamo.post.constant.SortType
 import com.zunza.gongsamo.post.dto.CreatePostRequest
 import com.zunza.gongsamo.post.dto.LocationFilter
 import com.zunza.gongsamo.post.dto.PostCursor
+import com.zunza.gongsamo.post.dto.PostDetailsResponse
 import com.zunza.gongsamo.post.dto.PostPageResponse
 import com.zunza.gongsamo.post.service.PostService
 import jakarta.validation.Valid
@@ -13,11 +14,11 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import java.time.LocalDateTime
 
 @RestController
 class PostController(
@@ -45,5 +46,13 @@ class PostController(
             size,
             postCursor
             ))
+    }
+
+    @GetMapping("/api/posts/{postId}")
+    fun getPostDetails(
+        @PathVariable postId: Long,
+        @AuthenticationPrincipal userId: Long? = null
+    ): ResponseEntity<PostDetailsResponse> {
+        return ResponseEntity.ok(postService.getPostDetails(postId, userId))
     }
 }

--- a/src/main/kotlin/com/zunza/gongsamo/post/dto/CreatePostRequest.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/dto/CreatePostRequest.kt
@@ -1,7 +1,7 @@
 package com.zunza.gongsamo.post.dto
 
 import com.fasterxml.jackson.annotation.JsonFormat
-import com.zunza.gongsamo.post.entity.SettlementType
+import com.zunza.gongsamo.post.constant.SettlementType
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import java.math.BigDecimal

--- a/src/main/kotlin/com/zunza/gongsamo/post/dto/PostDetailsResponse.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/dto/PostDetailsResponse.kt
@@ -1,0 +1,27 @@
+package com.zunza.gongsamo.post.dto
+
+import com.zunza.gongsamo.post.constant.PostStatus
+import com.zunza.gongsamo.post.constant.SettlementType
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+data class PostDetailsResponse(
+    val id: Long,
+    val hostName: String,
+    val title: String,
+    val description: String,
+    val settlementType: SettlementType,
+    val postStatus: PostStatus,
+    val productImageUrl: String?,
+    val productLink: String?,
+    val productPrice: BigDecimal,
+    val maxParticipants: Int,
+    val currentParticipants: Long,
+    val recruitmentDeadline: LocalDateTime,
+    val meetingPlace: String,
+    val x: String,
+    val y: String,
+    val isHost: Boolean,
+    val isParticipant: Boolean,
+    val createdAt: LocalDateTime
+)

--- a/src/main/kotlin/com/zunza/gongsamo/post/exception/PostNotFoundException.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/exception/PostNotFoundException.kt
@@ -1,0 +1,16 @@
+package com.zunza.gongsamo.post.exception
+
+import com.zunza.gongsamo.common.CustomException
+import org.springframework.http.HttpStatus
+
+class PostNotFoundException(
+    id: Long
+) : CustomException(MESSAGE + id) {
+
+    companion object {
+        private const val MESSAGE = "게시글을 찾을 수 없습니다: "
+    }
+
+    override fun getStatusCode() =
+        HttpStatus.NOT_FOUND.value()
+}

--- a/src/main/kotlin/com/zunza/gongsamo/post/repository/querydsl/CustomPostRepository.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/repository/querydsl/CustomPostRepository.kt
@@ -3,13 +3,10 @@ package com.zunza.gongsamo.post.repository.querydsl
 import com.zunza.gongsamo.post.constant.SortType
 import com.zunza.gongsamo.post.dto.LocationFilter
 import com.zunza.gongsamo.post.dto.PostCursor
+import com.zunza.gongsamo.post.dto.PostDetailsResponse
 import com.zunza.gongsamo.post.dto.PostPageResponse
 
 interface CustomPostRepository {
-    fun findPageByCursor(
-        locationFilter: LocationFilter,
-        sortType: SortType,
-        size: Int,
-        postCursor: PostCursor
-    ): PostPageResponse
+    fun findPageByCursor(locationFilter: LocationFilter, sortType: SortType, size: Int, postCursor: PostCursor): PostPageResponse
+    fun findPostDetailsById(postId: Long, userId: Long?): PostDetailsResponse?
 }

--- a/src/main/kotlin/com/zunza/gongsamo/post/service/PostService.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/post/service/PostService.kt
@@ -4,10 +4,12 @@ import com.zunza.gongsamo.post.constant.SortType
 import com.zunza.gongsamo.post.dto.CreatePostRequest
 import com.zunza.gongsamo.post.dto.LocationFilter
 import com.zunza.gongsamo.post.dto.PostCursor
+import com.zunza.gongsamo.post.dto.PostDetailsResponse
 import com.zunza.gongsamo.post.dto.PostPageResponse
 import com.zunza.gongsamo.post.entity.MeetingLocation
 import com.zunza.gongsamo.post.entity.Participant
 import com.zunza.gongsamo.post.entity.Post
+import com.zunza.gongsamo.post.exception.PostNotFoundException
 import com.zunza.gongsamo.post.repository.PostRepository
 import com.zunza.gongsamo.user.exception.UserNotFoundException
 import com.zunza.gongsamo.user.repository.UserRepository
@@ -49,5 +51,13 @@ class PostService(
             size,
             postCursor
         )
+    }
+
+    fun getPostDetails(
+        postId: Long,
+        userId: Long?
+    ): PostDetailsResponse? {
+        return postRepository.findPostDetailsById(postId, userId)
+            ?: throw PostNotFoundException(postId)
     }
 }


### PR DESCRIPTION
- GET /api/posts/{postId}를 통해 게시글 상세 정보를 조회할 수 있습니다.
- 현재 로그인한 사용자가 게시글의 '주최자(host)'인지, '참여자(participant)'인지를 판별하는 로직을 QueryDSL을 통해 구현하여 응답에 포함시켰습니다.