### PR TITLE
feat: FCM 연동 및 푸시 알림 기능 구현

### DIFF
--- a/src/main/kotlin/com/zunza/gongsamo/config/FirebaseConfig.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/config/FirebaseConfig.kt
@@ -1,0 +1,29 @@
+package com.zunza.gongsamo.config
+
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.messaging.FirebaseMessaging
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class FirebaseConfig {
+
+    @Bean
+    fun firebaseApp(): FirebaseApp {
+        val account = FirebaseConfig::class.java
+            .getResourceAsStream("/gongsamo-notification-firebase.json")
+
+        val options = FirebaseOptions.builder()
+            .setCredentials(GoogleCredentials.fromStream(account))
+            .build()
+
+        return FirebaseApp.initializeApp(options)
+    }
+
+    @Bean
+    fun firebaseMessaging(firebaseApp: FirebaseApp): FirebaseMessaging {
+        return FirebaseMessaging.getInstance(firebaseApp)
+    }
+}

--- a/src/main/kotlin/com/zunza/gongsamo/fcm/controller/FcmController.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/fcm/controller/FcmController.kt
@@ -1,0 +1,25 @@
+package com.zunza.gongsamo.fcm.controller
+
+import com.zunza.gongsamo.common.ApiResponse
+import com.zunza.gongsamo.fcm.dto.FcmTokenRequest
+import com.zunza.gongsamo.fcm.service.FcmService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class FcmController(
+    private val fcmService: FcmService
+) {
+    @PostMapping("/api/fcm/tokens")
+    fun saveToken(
+        @AuthenticationPrincipal userId: Long,
+        @RequestBody fcmTokenRequest: FcmTokenRequest
+    ): ResponseEntity<ApiResponse<Unit>> {
+        fcmService.saveToken(userId, fcmTokenRequest)
+        return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+}

--- a/src/main/kotlin/com/zunza/gongsamo/fcm/dto/FcmTokenRequest.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/fcm/dto/FcmTokenRequest.kt
@@ -1,0 +1,6 @@
+package com.zunza.gongsamo.fcm.dto
+
+data class FcmTokenRequest(
+    val token: String
+)
+

--- a/src/main/kotlin/com/zunza/gongsamo/fcm/entity/FcmToken.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/fcm/entity/FcmToken.kt
@@ -1,0 +1,33 @@
+package com.zunza.gongsamo.fcm.entity
+
+import com.zunza.gongsamo.common.BaseEntity
+import com.zunza.gongsamo.user.entity.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+
+@Entity
+class FcmToken(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @Column(unique = true, nullable = false)
+    var token: String,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    var user: User
+) : BaseEntity() {
+
+    companion object {
+        fun createOf(token: String, user: User): FcmToken {
+            return FcmToken(token = token, user = user)
+        }
+    }
+}

--- a/src/main/kotlin/com/zunza/gongsamo/fcm/exception/FcmTokenNotFoundException.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/fcm/exception/FcmTokenNotFoundException.kt
@@ -1,0 +1,16 @@
+package com.zunza.gongsamo.fcm.exception
+
+import com.zunza.gongsamo.common.CustomException
+import org.springframework.http.HttpStatus
+
+class FcmTokenNotFoundException(
+    val userId: Long
+) : CustomException(
+   MESSAGE.format(userId)
+) {
+    companion object {
+        private const val MESSAGE = "FCM 토큰을 찾을 수 없습니다. USER ID: %d"
+    }
+
+    override fun getStatusCode() = HttpStatus.NOT_FOUND.value()
+}

--- a/src/main/kotlin/com/zunza/gongsamo/fcm/repository/FcmTokenRepository.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/fcm/repository/FcmTokenRepository.kt
@@ -1,0 +1,11 @@
+package com.zunza.gongsamo.fcm.repository
+
+import com.zunza.gongsamo.fcm.entity.FcmToken
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface FcmTokenRepository : JpaRepository<FcmToken, Long> {
+    fun findByToken(token: String): FcmToken?
+    fun findByUserId(userId: Long): FcmToken?
+}

--- a/src/main/kotlin/com/zunza/gongsamo/fcm/service/FcmService.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/fcm/service/FcmService.kt
@@ -1,0 +1,62 @@
+package com.zunza.gongsamo.fcm.service
+
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.Message
+import com.google.firebase.messaging.Notification
+import com.google.firebase.messaging.WebpushConfig
+import com.google.firebase.messaging.WebpushNotification
+import com.zunza.gongsamo.fcm.dto.FcmTokenRequest
+import com.zunza.gongsamo.fcm.entity.FcmToken
+import com.zunza.gongsamo.fcm.exception.FcmTokenNotFoundException
+import com.zunza.gongsamo.fcm.repository.FcmTokenRepository
+import com.zunza.gongsamo.user.exception.UserNotFoundException
+import com.zunza.gongsamo.user.repository.UserRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class FcmService(
+    private val fcmTokenRepository: FcmTokenRepository,
+    private val firebaseMessaging: FirebaseMessaging,
+    private val userRepository: UserRepository
+) {
+    fun saveToken(userId: Long, fcmTokenRequest: FcmTokenRequest) {
+        val user = userRepository.findByIdOrNull(userId)
+            ?: throw UserNotFoundException(userId)
+
+        val token = fcmTokenRepository.findByToken(fcmTokenRequest.token)
+            ?.apply { this.user = user }
+            ?: FcmToken.createOf(fcmTokenRequest.token, user)
+
+        fcmTokenRepository.save(token)
+    }
+
+    fun sendNotificationToUser(receiverId: Long, title: String, body: String) {
+        val fcmToken = fcmTokenRepository.findByUserId(receiverId)
+            ?: throw FcmTokenNotFoundException(receiverId)
+
+
+        val message = Message.builder()
+            .setToken(fcmToken.token)
+            .setNotification(
+                Notification.builder()
+                    .setTitle(title)
+                    .setBody(body)
+                    .build()
+            )
+            .setWebpushConfig(
+                WebpushConfig.builder()
+                    .setNotification(
+                        WebpushNotification.builder()
+                            .setTitle(title)
+                            .setBody(body)
+                            .build()
+                    )
+                    .build()
+            )
+//            .putAllData()
+            .build()
+
+        firebaseMessaging.send(message)
+    }
+}


### PR DESCRIPTION
Firebase Cloud Messaging(FCM)을 사용하여 서버에서 클라이언트로 푸시 알림을 보낼 수 있는 기능을 구현했습니다.

- FcmController: 클라이언트의 FCM 토큰을 저장하는 API 엔드포인트를 추가했습니다.
- FcmService: FCM 토큰 저장 및 특정 사용자에게 알림을 전송하는 로직을 구현했습니다.