### PR TITLE
feat: 공동구매 참여 및 참여 취소 기능 구현

### DIFF
--- a/src/main/kotlin/com/zunza/gongsamo/participant/controller/ParticipantController.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/participant/controller/ParticipantController.kt
@@ -1,0 +1,34 @@
+package com.zunza.gongsamo.participant.controller
+
+import com.zunza.gongsamo.common.ApiResponse
+import com.zunza.gongsamo.participant.service.ParticipantService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ParticipantController(
+    private val participantService: ParticipantService
+) {
+    @PostMapping("/api/posts/{postId}/participants")
+    fun participate(
+        @PathVariable postId: Long,
+        @AuthenticationPrincipal userId: Long
+    ): ResponseEntity<ApiResponse<Unit>> {
+        participantService.createParticipation(postId, userId)
+        return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+
+    @DeleteMapping("/api/posts/{postId}/participants")
+    fun cancelParticipation(
+        @PathVariable postId: Long,
+        @AuthenticationPrincipal userId: Long
+    ): ResponseEntity<ApiResponse<Unit>> {
+        participantService.deleteParticipation(postId, userId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/zunza/gongsamo/participant/entity/Participant.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/participant/entity/Participant.kt
@@ -1,0 +1,41 @@
+package com.zunza.gongsamo.participant.entity
+
+import com.zunza.gongsamo.common.BaseEntity
+import com.zunza.gongsamo.post.entity.Post
+import com.zunza.gongsamo.user.entity.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+
+@Entity
+class Participant(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    val post: Post,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    val user: User,
+
+    @Column(nullable = false)
+    val isHost: Boolean = false,
+
+    @Column(nullable = false)
+    var settlementConfirmed: Boolean = false
+) : BaseEntity() {
+
+    companion object {
+        fun createOf(post: Post, user: User, isHost: Boolean = false): Participant {
+            return Participant(post = post, user = user, isHost = isHost)
+        }
+    }
+}

--- a/src/main/kotlin/com/zunza/gongsamo/participant/exception/AlreadyParticipatedException.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/participant/exception/AlreadyParticipatedException.kt
@@ -1,0 +1,17 @@
+package com.zunza.gongsamo.participant.exception
+
+import com.zunza.gongsamo.common.CustomException
+import org.springframework.http.HttpStatus
+
+class AlreadyParticipatedException(
+    val postId: Long,
+    val userId: Long
+) : CustomException(
+    MESSAGE.format(postId, userId)
+) {
+    companion object {
+        private const val MESSAGE = "이미 참여 중인 공동구매입니다. POST ID: %d, REQUESTER ID: %d"
+    }
+
+    override fun getStatusCode() = HttpStatus.CONFLICT.value()
+}

--- a/src/main/kotlin/com/zunza/gongsamo/participant/exception/ParticipantNotFoundException.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/participant/exception/ParticipantNotFoundException.kt
@@ -1,0 +1,17 @@
+package com.zunza.gongsamo.participant.exception
+
+import com.zunza.gongsamo.common.CustomException
+import org.springframework.http.HttpStatus
+
+class ParticipantNotFoundException(
+    val postId: Long,
+    val requesterId: Long
+) : CustomException(
+    MESSAGE.format(postId, requesterId)
+) {
+    companion object {
+        private const val MESSAGE = "참여 정보를 찾을 수 없습니다. POST ID: %d, REQUESTER ID: %d"
+    }
+
+    override fun getStatusCode() = HttpStatus.NOT_FOUND.value()
+}

--- a/src/main/kotlin/com/zunza/gongsamo/participant/exception/ParticipationQuotaExceededException.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/participant/exception/ParticipationQuotaExceededException.kt
@@ -1,0 +1,16 @@
+package com.zunza.gongsamo.participant.exception
+
+import com.zunza.gongsamo.common.CustomException
+import org.springframework.http.HttpStatus
+
+class ParticipationQuotaExceededException(
+    val postId: Long
+) : CustomException(
+    MESSAGE.format(postId)
+) {
+    companion object {
+        private const val MESSAGE = "참여 인원이 모두 찼습니다. POST ID: %d"
+    }
+
+    override fun getStatusCode() = HttpStatus.CONFLICT.value()
+}

--- a/src/main/kotlin/com/zunza/gongsamo/participant/exception/PostNotRecruitingException.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/participant/exception/PostNotRecruitingException.kt
@@ -1,0 +1,16 @@
+package com.zunza.gongsamo.participant.exception
+
+import com.zunza.gongsamo.common.CustomException
+import org.springframework.http.HttpStatus
+
+class PostNotRecruitingException(
+    val postId: Long
+) : CustomException(
+    MESSAGE.format(postId)
+) {
+    companion object {
+        private const val MESSAGE = "모집이 마감된 공동구매입니다. POST ID: %d"
+    }
+
+    override fun getStatusCode() = HttpStatus.BAD_REQUEST.value()
+}

--- a/src/main/kotlin/com/zunza/gongsamo/participant/exception/SelfParticipationNotAllowedException.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/participant/exception/SelfParticipationNotAllowedException.kt
@@ -1,0 +1,18 @@
+package com.zunza.gongsamo.participant.exception
+
+import com.zunza.gongsamo.common.CustomException
+import org.springframework.http.HttpStatus
+
+class SelfParticipationNotAllowedException(
+    postId: Long,
+    hostId: Long,
+    requesterId: Long
+) : CustomException(
+    MESSAGE.format(postId, hostId, requesterId)
+) {
+    companion object {
+        private const val MESSAGE = "호스트는 자신의 공동구매에 참가 신청할 수 없습니다. POST ID: %d, HOST ID: %d, REQUESTER ID: %d"
+    }
+
+    override fun getStatusCode() = HttpStatus.BAD_REQUEST.value()
+}

--- a/src/main/kotlin/com/zunza/gongsamo/participant/repository/ParticipantRepository.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/participant/repository/ParticipantRepository.kt
@@ -1,0 +1,14 @@
+package com.zunza.gongsamo.participant.repository
+
+import com.zunza.gongsamo.participant.entity.Participant
+import com.zunza.gongsamo.post.entity.Post
+import com.zunza.gongsamo.user.entity.User
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ParticipantRepository : JpaRepository<Participant, Long> {
+    fun existsByPostAndUser(post: Post, user: User): Boolean
+    fun countByPost(post: Post): Long
+    fun findByPostIdAndUserId(postId: Long, userId: Long): Participant?
+}

--- a/src/main/kotlin/com/zunza/gongsamo/participant/service/ParticipantService.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/participant/service/ParticipantService.kt
@@ -1,0 +1,81 @@
+package com.zunza.gongsamo.participant.service
+
+import com.zunza.gongsamo.notification.dto.ParticipantCreatedEvent
+import com.zunza.gongsamo.participant.entity.Participant
+import com.zunza.gongsamo.participant.exception.AlreadyParticipatedException
+import com.zunza.gongsamo.participant.exception.ParticipantNotFoundException
+import com.zunza.gongsamo.participant.exception.ParticipationQuotaExceededException
+import com.zunza.gongsamo.participant.exception.PostNotRecruitingException
+import com.zunza.gongsamo.participant.exception.SelfParticipationNotAllowedException
+import com.zunza.gongsamo.participant.repository.ParticipantRepository
+import com.zunza.gongsamo.post.constant.PostStatus
+import com.zunza.gongsamo.post.exception.PostNotFoundException
+import com.zunza.gongsamo.post.repository.PostRepository
+import com.zunza.gongsamo.user.exception.UserNotFoundException
+import com.zunza.gongsamo.user.repository.UserRepository
+import jakarta.transaction.Transactional
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class ParticipantService(
+    private val postRepository: PostRepository,
+    private val userRepository: UserRepository,
+    private val participantRepository: ParticipantRepository,
+    private val applicationEventPublisher: ApplicationEventPublisher
+) {
+    /**
+     * TODO 동시성 문제 확인(lock 알아보기) | 알림 보내기
+     */
+    @Transactional
+    fun createParticipation(postId: Long, userId: Long) {
+        val post = postRepository.findByIdOrNull(postId)
+            ?: throw PostNotFoundException(postId)
+
+        val user = userRepository.findByIdOrNull(userId)
+            ?: throw UserNotFoundException(userId)
+
+        // 셀프 참여인가(host 인가)
+        if (post.host.id == user.id) {
+            throw SelfParticipationNotAllowedException(
+                postId,
+                post.host.id,
+                userId
+            )
+        }
+        // 이미 참여
+        if (participantRepository.existsByPostAndUser(post, user)) {
+            throw AlreadyParticipatedException(postId, userId)
+        }
+        // 모집 중인가
+        if (post.status != PostStatus.RECRUITING) {
+            throw PostNotRecruitingException(postId)
+        }
+
+        // 자리 남았는가
+        val currentParticipants = participantRepository.countByPost(post)
+        if (currentParticipants >= post.maxParticipants) {
+            throw ParticipationQuotaExceededException(postId)
+        }
+
+        // participant 생성
+        participantRepository.save(Participant.createOf(post, user))
+
+        // 알림 발송
+        applicationEventPublisher.publishEvent(
+            ParticipantCreatedEvent.createOf(
+            post.host.id,
+            user.nickname,
+            post.title
+            )
+        )
+    }
+
+    fun deleteParticipation(postId: Long, userId: Long) {
+        val participant = participantRepository.findByPostIdAndUserId(postId, userId)
+            ?: throw ParticipantNotFoundException(postId, userId)
+
+        participantRepository.delete(participant)
+    }
+}


### PR DESCRIPTION
사용자가 게시글(모임/공동구매)에 참여를 신청하거나 취소할 수 있는 API를 구현했습니다.

- 게시글 참여 (POST /api/posts/{postId}/participants)
  - 사용자가 특정 게시글에 참여를 신청합니다.
  - 주최자의 셀프 참여 방지
  - 중복 참여 방지
  - 모집 상태(RECRUITING) 확인
  - 참여 정원 초과 여부 확인
  - 참여가 성공하면, 게시글 주최자에게 알림을 보내기 위해 ParticipantCreatedEvent를 발행합니다.
- 참여 취소 (DELETE /api/posts/{postId}/participants)
  - 사용자가 기존에 신청했던 참여를 취소합니다.