### PR TITLE
feat: 이벤트 리스너를 통한 비동기 알림 처리 구현

### DIFF
--- a/src/main/kotlin/com/zunza/gongsamo/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/config/AsyncConfig.kt
@@ -1,0 +1,24 @@
+package com.zunza.gongsamo.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+
+@EnableAsync
+@Configuration
+class AsyncConfig {
+
+    @Bean(name = ["fcmNotificationExecutor"])
+    fun fcmNotificationExecutor(): Executor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = 5
+        executor.maxPoolSize = 10
+        executor.queueCapacity = 20
+        executor.setThreadNamePrefix("fcmExecutor")
+        executor.setWaitForTasksToCompleteOnShutdown(true)
+        executor.initialize()
+        return executor
+    }
+}

--- a/src/main/kotlin/com/zunza/gongsamo/notification/dto/ParticipantCreatedEvent.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/notification/dto/ParticipantCreatedEvent.kt
@@ -1,0 +1,27 @@
+package com.zunza.gongsamo.notification.dto
+
+class ParticipantCreatedEvent(
+    val hostId: Long,
+    val participantNickname: String,
+    val postTitle: String
+) {
+    val notificationTitle: String
+        get() = "새로운 참여자가 등장했어요!"
+
+    val notificationBody: String
+        get() = "${participantNickname}님이 [${postTitle}] 공동구매에 참여했습니다!"
+
+    companion object {
+        fun createOf(
+            hostId: Long,
+            participantNickname: String,
+            postTitle: String
+        ): ParticipantCreatedEvent {
+            return ParticipantCreatedEvent(
+                hostId,
+                participantNickname,
+                postTitle
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/zunza/gongsamo/notification/listener/NotificationEventListener.kt
+++ b/src/main/kotlin/com/zunza/gongsamo/notification/listener/NotificationEventListener.kt
@@ -1,0 +1,22 @@
+package com.zunza.gongsamo.notification.listener
+
+import com.zunza.gongsamo.fcm.service.FcmService
+import com.zunza.gongsamo.notification.dto.ParticipantCreatedEvent
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class NotificationEventListener(
+    private val fcmService: FcmService
+) {
+    @Async("fcmNotificationExecutor")
+    @TransactionalEventListener
+    fun handleParticipantCreatedEvent(event: ParticipantCreatedEvent) {
+        fcmService.sendNotificationToUser(
+            event.hostId,
+            event.notificationTitle,
+            event.notificationBody
+        )
+    }
+}


### PR DESCRIPTION
게시글 참여와 같은 비즈니스 로직 실행 시, FCM 알림 발송으로 인한 API 응답 지연을 해결하기 위해 비동기 이벤트 처리 방식을 도입했습니다.

- 비동기 처리 활성화: @EnableAsync 및 알림 전용 ThreadPoolTaskExecutor를 설정하여 비동기 환경을 구성했습니다.
- 이벤트 리스너 구현: ParticipantCreatedEvent를 수신하는 NotificationEventListener를 추가했습니다.
- 트랜잭션 연동: @TransactionalEventListener를 사용하여, 주 비즈니스 로직의 트랜잭션이 성공적으로 커밋된 후에만 알림을 보내도록 했습니다.